### PR TITLE
only debug HTTParty requests on dev

### DIFF
--- a/lib/ruby-mws/api/base.rb
+++ b/lib/ruby-mws/api/base.rb
@@ -7,7 +7,7 @@ module MWS
     class Base
       include HTTParty
       parser MWS::API::BinaryParser
-      debug_output $stderr  # only in development
+      debug_output $stderr if Rails.env.development? # only in development
       #format :xml
       headers "User-Agent"   => "ruby-mws/#{MWS::VERSION} (Language=Ruby/1.9.3-p0)"
       headers "Content-Type" => "text/xml"


### PR DESCRIPTION
There is a comment in this file that says `# only in development` but there is nothing to make that actually true.

Per [this question on Stack Overflow](http://stackoverflow.com/questions/18132148/how-to-control-httparty-output-using-a-rails-logger) it might be better to add `if Rails.env.development?`

However, I would also like a way to disable this output in the development environment, but I don't see an easy way that I can do that from an initializer or my application config - do you have any suggestions - or could we add that feature, please?