### PR TITLE
PS-4668 update fulfillment date of shipped orders

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -134,4 +134,6 @@ marketplace_id: '[marketplace id]'
 
 Then run `bundle exec rspec spec/`
 
-There's still work and research to be done on how to integrate our changes in with the author's. Because we're using different credentials than the author and there are hardcodede order ids in the specs we'll never have all the specs passing for all of us.
+To use binding.pry in a spec, be sure to require it with `require 'pry'`.
+
+There's still work and research to be done on how to integrate our changes in with the author's. Because we're using different credentials than the author and there are hardcoded order ids in the specs we'll never have all the specs passing for all of us.

--- a/lib/ruby-mws/api/feed.rb
+++ b/lib/ruby-mws/api/feed.rb
@@ -236,7 +236,7 @@ module MWS
         end.to_xml
       end
 
-      # Returns a string containing the shipping achnowledgement xml
+      # Returns a string containing the shipping acknowledgement xml
       #
       # @param [Hash{Symbol => String,Array,DateTime}] opts contains:
       # @option opts [Array<Hash>] :orders order specifics including:
@@ -252,11 +252,12 @@ module MWS
       #     :amazon_order_item_code
       #     :quantity keys
       #   @option opts [String] :tracking_number (optional) shipper tracking number
-      #   @option opts [String] :fulfillment_date (optional) DateTime the order was fulfilled
-      #     defaults to the current time
+      #   @option opts [String] :fulfillment_date (optional) DateTime the orders were fulfilled
+      #     defaults to the current time but an individual order's fulfillment date is
+      #     sent in preference over either of the defaults
       #   @option opts [String] :merchant_order_item_id Internal order line item id
       def content_for_ship_with(opts={})
-        fulfillment_date = opts[:fulfillment_date] || DateTime.now
+        orders_fulfillment_date = opts[:fulfillment_date] || DateTime.now
 
         amazon_envelope_with_header do |xml|
           xml.MessageType "OrderFulfillment"
@@ -265,7 +266,7 @@ module MWS
               xml.MessageID order_hash[:message_id]
               xml.OrderFulfillment {
                 xml.AmazonOrderID order_hash[:amazon_order_id]
-                xml.FulfillmentDate fulfillment_date
+                xml.FulfillmentDate order_hash[:fulfillment_date] || orders_fulfillment_date
                 xml.FulfillmentData {
                   xml.CarrierCode order_hash[:carrier_code]
                   xml.ShippingMethod order_hash[:shipping_method]

--- a/lib/ruby-mws/version.rb
+++ b/lib/ruby-mws/version.rb
@@ -1,3 +1,3 @@
 module MWS
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/spec/ruby-mws/api/feed_spec.rb
+++ b/spec/ruby-mws/api/feed_spec.rb
@@ -11,7 +11,8 @@ describe MWS::API::Feed do
     let(:first_order_id) {'105-8268075-6520231'}
     let(:second_order_id) {'105-8268075-6520232'}
     let(:order_ack_order_id){'105-1063273-7151427'}
-    let(:fulfillment_date){DateTime.now}
+    let(:orders_fulfillment_date) { DateTime.now }
+    let(:first_order_fulfillment) { Date.parse('2016-01-01') }
     let(:carrier_code){'UPS'}
     let(:shipping_method){'2nd Day'}
     let(:tracking_number){'123321123321'}
@@ -21,9 +22,10 @@ describe MWS::API::Feed do
     let(:fourth_item_code){'62918663121792'}
     let(:shipment_hash) {
       {
-        :fulfillment_date => fulfillment_date,
+        :fulfillment_date => orders_fulfillment_date,
         :orders => [ {
                        :amazon_order_id => first_order_id,
+                       :fulfillment_date => first_order_fulfillment,
                        :shipping_method => shipping_method,
                        :carrier_code => carrier_code,
                        :tracking_number => tracking_number,
@@ -328,7 +330,8 @@ describe MWS::API::Feed do
           body_doc.css('AmazonEnvelope MessageType').length.should == 1 # multiple types was causing problems
           body_doc.css('AmazonEnvelope Message OrderFulfillment').should_not be_empty
           body_doc.css('AmazonEnvelope Message OrderFulfillment AmazonOrderID').should_not be_empty
-          body_doc.css('AmazonEnvelope Message OrderFulfillment FulfillmentDate').first.text.should == fulfillment_date.to_s
+          body_doc.css('AmazonEnvelope Message OrderFulfillment FulfillmentDate').first.text.should == first_order_fulfillment.to_s
+          body_doc.css('AmazonEnvelope Message OrderFulfillment FulfillmentDate').last.text.should == orders_fulfillment_date.to_s
           body_doc.css('AmazonEnvelope Message OrderFulfillment FulfillmentData').should_not be_empty
           body_doc.css('AmazonEnvelope Message OrderFulfillment FulfillmentData CarrierCode').first.text.should == carrier_code
           body_doc.css('AmazonEnvelope Message OrderFulfillment FulfillmentData ShippingMethod').first.text.should == shipping_method


### PR DESCRIPTION
Reverts blurb/ruby-mws#17 in order to add the changes from https://github.com/blurb/ruby-mws/pull/16 back in.

The original changes were correct. The issue was on Blurby's side, which sent a Date object rather than DateTime. Blurby PR in progress -> will be taking the Date stored in db, convert to DateTime, then send over.