### PR TITLE
ps-5875 migrate to 2013-09-01 Orders api

### DIFF
--- a/lib/ruby-mws/api/order.rb
+++ b/lib/ruby-mws/api/order.rb
@@ -4,8 +4,8 @@ module MWS
     class Order < Base
       def_request [:list_orders, :list_orders_by_next_token],
         :verb => :get,
-        :uri => '/Orders/2011-01-01',
-        :version => '2011-01-01',
+        :uri => '/Orders/2013-09-01',
+        :version => '2013-09-01',
         :lists => {
           :order_status => "OrderStatus.Status",
           :marketplace_id => "MarketplaceId.Id"
@@ -17,8 +17,8 @@ module MWS
 
       def_request [:list_order_items, :list_order_items_by_next_token],
         :verb => :get,
-        :uri => '/Orders/2011-01-01',
-        :version => '2011-01-01',
+        :uri => '/Orders/2013-09-01',
+        :version => '2013-09-01',
         :lists => {
           :marketplace_id => "MarketplaceId.Id"
         },
@@ -28,8 +28,8 @@ module MWS
 
       def_request :get_order,
         :verb => :get,
-        :uri => '/Orders/2011-01-01',
-        :version => '2011-01-01',
+        :uri => '/Orders/2013-09-01',
+        :version => '2013-09-01',
         :lists => {
           :amazon_order_id => "AmazonOrderId.Id",
           :marketplace_id => "MarketplaceId.Id"

--- a/lib/ruby-mws/version.rb
+++ b/lib/ruby-mws/version.rb
@@ -1,3 +1,3 @@
 module MWS
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/spec/fixtures/list_orders_canonical.txt
+++ b/spec/fixtures/list_orders_canonical.txt
@@ -1,4 +1,4 @@
 GET
 mws.amazonservices.com
-/Orders/2011-01-01
-AWSAccessKeyId=access&Action=ListOrders&LastUpdatedAfter=2012-01-13T15%3A48%3A55-05%3A00&MarketplaceId.Id.1=ATVPDKIKX0DER&SellerId=A27WNMSA8OPBXY&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2012-01-14T15%3A48%3A55-05%3A00&Version=2011-01-01
+/Orders/2013-09-01
+AWSAccessKeyId=access&Action=ListOrders&LastUpdatedAfter=2012-01-13T15%3A48%3A55-05%3A00&MarketplaceId.Id.1=ATVPDKIKX0DER&SellerId=A27WNMSA8OPBXY&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2012-01-14T15%3A48%3A55-05%3A00&Version=2013-09-01

--- a/spec/ruby-mws/api/base_spec.rb
+++ b/spec/ruby-mws/api/base_spec.rb
@@ -5,8 +5,8 @@ describe MWS::API::Base do
     def self.test_params
       {
         :verb    => :get,
-        :uri     => '/FakeApi/2011-01-01',
-        :version => '2011-01-01'
+        :uri     => '/FakeApi/2013-09-01',
+        :version => '2013-09-01'
       }
     end
 

--- a/spec/ruby-mws/api/query_spec.rb
+++ b/spec/ruby-mws/api/query_spec.rb
@@ -10,14 +10,14 @@ describe MWS::API::Query do
     it "should assemble the canonical query" do
       @query.canonical.should == %Q{GET
 mws.amazonservices.com
-/Orders/2011-01-01
-AWSAccessKeyId=#{default_params[:aws_access_key_id]}&Action=ListOrders&LastUpdatedAfter=2012-01-13T15%3A48%3A55-05%3A00&MarketplaceId.Id.1=#{default_params[:marketplace_id]}&SellerId=#{default_params[:seller_id]}&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2012-01-14T15%3A48%3A55-05%3A00&Version=2011-01-01}
+/Orders/2013-09-01
+AWSAccessKeyId=#{default_params[:aws_access_key_id]}&Action=ListOrders&LastUpdatedAfter=2012-01-13T15%3A48%3A55-05%3A00&MarketplaceId.Id.1=#{default_params[:marketplace_id]}&SellerId=#{default_params[:seller_id]}&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2012-01-14T15%3A48%3A55-05%3A00&Version=2013-09-01}
     end
   end
 
   context ".request_uri" do
     it "should assemble the request uri" do
-      @query.request_uri.should == "https://mws.amazonservices.com/Orders/2011-01-01?AWSAccessKeyId=#{default_params[:aws_access_key_id]}&Action=ListOrders&LastUpdatedAfter=2012-01-13T15%3A48%3A55-05%3A00&MarketplaceId.Id.1=#{default_params[:marketplace_id]}&SellerId=#{default_params[:seller_id]}&Signature=SIGNATURE&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2012-01-14T15%3A48%3A55-05%3A00&Version=2011-01-01"
+      @query.request_uri.should == "https://mws.amazonservices.com/Orders/2013-09-01?AWSAccessKeyId=#{default_params[:aws_access_key_id]}&Action=ListOrders&LastUpdatedAfter=2012-01-13T15%3A48%3A55-05%3A00&MarketplaceId.Id.1=#{default_params[:marketplace_id]}&SellerId=#{default_params[:seller_id]}&Signature=SIGNATURE&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2012-01-14T15%3A48%3A55-05%3A00&Version=2013-09-01"
     end
   end
 
@@ -37,8 +37,8 @@ AWSAccessKeyId=#{default_params[:aws_access_key_id]}&Action=ListOrders&LastUpdat
     params = {
       :last_updated_after => "2012-01-13T15:48:55-05:00",
       :verb               => :get,
-      :uri                => "/Orders/2011-01-01",
-      :version            => "2011-01-01",
+      :uri                => "/Orders/2013-09-01",
+      :version            => "2013-09-01",
       :host               => "mws.amazonservices.com",
       :action             => "ListOrders",
       :signature_method   => "HmacSHA256",


### PR DESCRIPTION
https://blurb-books.atlassian.net/browse/PS-5875

Looked through the APIs we use in blurby and I think it's actually a drop-in replacement. Not seeing any discrepancies. I see in the readme we expect some tests to fail, all the same tests fail with the old api versus the new. (Looks like the gem basically just check for amazon_order_id existing within the responses)

A future card would have us switch gems entirely to a well-maintained open source alternative so we don't have to maintain this any longer. See https://blurb-books.atlassian.net/browse/PS-5876