### PR TITLE
[WAT-410] Add more info in error

### DIFF
--- a/lib/ruby-mws/api/response.rb
+++ b/lib/ruby-mws/api/response.rb
@@ -10,7 +10,8 @@ module MWS
         if !rash.keys.nil? && rash.keys.first == "amazon_envelope"
           rash
         else
-          raise BadResponseError, "received non-matching response type #{rash.keys} code: #{rash.try(:error_response).try(:error).try(:code)} message: #{rash.try(:error_response).try(:error).try(:message)}" if rash["#{name}_response"].nil? 
+          err_msg = rash.try(:error_response).try(:error)
+          raise BadResponseError, "received non-matching response type #{rash.keys} code: #{err_msg.try(:code)} message: #{err_msg.try(:message)}" if rash["#{name}_response"].nil?
           rash = rash["#{name}_response"]
 
           if rash = rash["#{name}_result"]

--- a/lib/ruby-mws/api/response.rb
+++ b/lib/ruby-mws/api/response.rb
@@ -10,7 +10,7 @@ module MWS
         if !rash.keys.nil? && rash.keys.first == "amazon_envelope"
           rash
         else
-          raise BadResponseError, "received non-matching response type #{rash.keys}" if rash["#{name}_response"].nil? 
+          raise BadResponseError, "received non-matching response type #{rash.keys} code: #{rash.try(:error_response).try(:error).try(:code)} message: #{rash.try(:error_response).try(:error).try(:message)}" if rash["#{name}_response"].nil? 
           rash = rash["#{name}_response"]
 
           if rash = rash["#{name}_result"]

--- a/lib/ruby-mws/version.rb
+++ b/lib/ruby-mws/version.rb
@@ -1,3 +1,3 @@
 module MWS
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end


### PR DESCRIPTION
MWS response should return more descriptive code and error message.
Story:
https://blurb-books.atlassian.net/browse/WAT-410
Error msg:
Before:
"received non-matching response type [\"error_response\"]"

After:
"received non-matching response type [\"error_response\"] code: FeedProcessingResultNotReady message: Feed Submission Result is not ready for Feed 171519017655"