### PR TITLE
PLAT-2107: Provide handling time (= fulfillment latency) for new titles

### DIFF
--- a/lib/ruby-mws/api/feed.rb
+++ b/lib/ruby-mws/api/feed.rb
@@ -111,7 +111,7 @@ module MWS
               xml.Inventory {
                 xml.SKU entry[:isbn]
                 xml.Quantity entry[:quantity]
-                xml.FulfillmentLatency entry[:fulfillment_latency]
+                xml.FulfillmentLatency entry[:fulfillment_latency] || 5
               }
             }
           end

--- a/lib/ruby-mws/api/feed.rb
+++ b/lib/ruby-mws/api/feed.rb
@@ -111,6 +111,7 @@ module MWS
               xml.Inventory {
                 xml.SKU entry[:isbn]
                 xml.Quantity entry[:quantity]
+                xml.FulfillmentLatency entry[:fulfillment_latency]
               }
             }
           end

--- a/lib/ruby-mws/version.rb
+++ b/lib/ruby-mws/version.rb
@@ -1,3 +1,3 @@
 module MWS
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end

--- a/spec/ruby-mws/api/feed_spec.rb
+++ b/spec/ruby-mws/api/feed_spec.rb
@@ -174,7 +174,8 @@ describe MWS::API::Feed do
         :operation_type => 'Update',
         :isbn => '9781320717869',
         :currency => 'USD',
-        :quantity => '100'
+        :quantity => '100',
+        :fulfillment_latency => '5'
       }
     }
 
@@ -183,7 +184,8 @@ describe MWS::API::Feed do
         :message_id => 2,
         :operation_type => 'Update',
         :isbn => '9781320717870',
-        :quantity => '200'
+        :quantity => '200',
+        :fulfillment_latency => '5'
       }
     }
 
@@ -434,6 +436,8 @@ describe MWS::API::Feed do
             body_doc.css('AmazonEnvelope PurgeAndReplace').text.should == "false"
             body_doc.css('AmazonEnvelope Message Inventory Quantity')[0].text.should == "100"
             body_doc.css('AmazonEnvelope Message Inventory Quantity')[1].text.should == "200"
+            body_doc.css('AmazonEnvelope Message Inventory FulfillmentLatency')[0].text.should == "5"
+            body_doc.css('AmazonEnvelope Message Inventory FulfillmentLatency')[1].text.should == "5"
           end
           response = mws.feeds.submit_feed(MWS::API::Feed::PRODUCT_LIST_INVENTORY, product_inventory_hash_list)
         end


### PR DESCRIPTION
Amazon MWS: Inventory Feed: for the Product List Inventory feed, adds the `FulfillmentLatency` property to the generated XML, which will be provided by blurby.